### PR TITLE
fix(duolingo): fix CLI outputs for feed and league

### DIFF
--- a/duolingo/__snapshots__/cli.test.ts.snap
+++ b/duolingo/__snapshots__/cli.test.ts.snap
@@ -2,305 +2,329 @@ export const snapshot = {};
 
 snapshot[`duolingo feed 1`] = `
 "
-  Mary Borisova did more than 10 lessons in a day!
-  Ольга ✨ reached a duolingo english score of 127!
-  susan completed 70 friends quests in a row!
-  Zaineb collected the april badge!
-  Zaineb completed 3 friends quests in a row!
-  huyen did more than 10 lessons in a day!
-♥︎ Ariana Khodyreva played 5 chess matches in a day!
-♥︎ it's nazli 12 tacowa played 5 chess matches in a day!
-♥︎ it's nazli 12 tacowa did more than 10 lessons in a day!
-♥︎ Ariana Khodyreva won 10 chess matches. check and mate!
-♥︎ piccola reached a duolingo italian score of 63!
-♥︎ Anna and Sandra reached a 125 day friend streak!
-♥︎ angeles soto lopez completed 15 friends quests in a row!
-♥︎ Cindy finished #1 in the diamond league 100 times!
-♥︎ &ko collected the april badge!
-♥︎ Piet collected the april badge!
-♥︎ Татьяна completed 65 friends quests in a row!
-♥︎ Vanessa Ortega completed a 100 day streak!
-♥︎ Vanessa and Daicy reached a 50 day friend streak!
-♥︎ ♡M♡ shared a sentence
-♥︎ Kitsunet20170403 completed a 250 day streak!
-♥︎ Smt S completed 35 friends quests in a row!
-♥︎ Arlette and El reached a 575 day friend streak!
-♥︎ ✨ and Reyyan reached a 30 day friend streak!
-♥︎ ♡M♡ shared a sentence
-♥︎ ♡M♡ shared a sentence
-♥︎ Ricky Harper reached a duolingo english score of 130!
-♥︎ Roberto completed 5 friends quests in a row!
-♥︎ HalloI’m Japanese I like game finished top 3 and was promoted to the amethyst league!
-♥︎ mi completed 10 friends quests in a row!
-♥︎ carito and LizzyLegend#7 reached a 3 day friend streak!
-♥︎ Bob advanced to the finals of the diamond tournament!
-♥︎ liseth Castro completed a 7 day streak!
-♥︎ Mayara advanced to the semifinals of the diamond tournament!
-♥︎ Svitlana and Stephen reached a 675 day friend streak!
-♥︎ AŽ collected the april badge!
-♥︎ @Amin_mgh99 collected the april badge!
-♥︎ Quintin and Ibtissam reached a 30 day friend streak!
-♥︎ Regulita and gaborke reached a 50 day friend streak!
-♥︎ Smt and Bahar reached a 200 day friend streak!
-♥︎ CashBuckets reached a duolingo english score of 60!
-♥︎ Sarka completed 80 friends quests in a row!
-♥︎ Aylin and Leyla reached a 75 day friend streak!
-♥︎ Theodor Berkinblit collected the april badge!
-♥︎ Vicky collected the april badge!
-♥︎ Lololo124 reached a duolingo italian score of 8!
-♥︎ Bilge Özkan Özkavak collected the april badge!
-♥︎ محمد اسماعيل علي مهدي الموشكي reached a duolingo english score of 78!
-♥︎ [♤you and Nurettin reached a 3 day friend streak!
-♥︎ Vanessa shared a sentence
-♥︎ Татьяна did more than 10 lessons in a day!
-♥︎ Vanessa shared a sentence
-♥︎ Hamza reached a duolingo english score of 88!
-♥︎ Damla completed 3 friends quests in a row!
-♥︎ Миша and Светлана reached a 3 day friend streak!
-♥︎ Cris completed 5 friends quests in a row!
-♥︎ Sebastian and Ailing reached a 125 day friend streak!
-♥︎ kocymm completed a total of 50 perfect lessons!
-♥︎ منصف did more than 10 lessons in a day!
-♥︎ io finished top 3 and was promoted to the amethyst league!
-♥︎ Çınar Sezen reached a duolingo english score of 129!
-♥︎ Jacksmack704 collected the april badge!
-♥︎ rita and Deme reached a 325 day friend streak!
-♥︎ Koss collected the april badge!
-♥︎ Çınar Sezen won 50 chess matches. check and mate!
-♥︎ Cris and Антон reached a 3 day friend streak!
-♥︎ Cemre and Eda reached a 50 day friend streak!
-♥︎ abc completed 30 friends quests in a row!
-♥︎ abc and Yuu reached a 14 day friend streak!
-♥︎ Mapali and Werner reached a 200 day friend streak!
-♥︎ Elenise did more than 10 lessons in a day!
-♥︎ ANONYME 2015 won their first chess match. checkmate!
-♥︎ Erone2016 collected the april badge!
-♥︎ Sandra reached a duolingo spanish score of 91!
-♥︎ Robin and Donncha reached a 650 day friend streak!
-♥︎ atas and Natalia reached a 365 day friend streak!
-♥︎ Mobsbacke and Charlie reached a 14 day friend streak!
-♥︎ leroi555 collected the april badge!
-♥︎ Jun and Милана reached a 3 day friend streak!
-♥︎ Anna won 4350 chess matches. check and mate!
-  undefined struggling to know *which* chess move is best during your games? read our tips!
-♥︎ Emine and nguyễn reached a 550 day friend streak!
-♥︎ Nick and Fred reached a 475 day friend streak!
-♥︎ Delcy and Zulay reached a 675 day friend streak!
-♥︎ Trần HaNa won their first chess match. checkmate!
-♥︎ Ricky Harper completed 3 friends quests in a row!
-♥︎ Mobsbacke completed a 50 day streak!
-♥︎ Trần HaNa reached a duolingo english score of 25!
-♥︎ Trần HaNa collected the april badge!
-♥︎ Sandra completed 55 friends quests in a row!
-♥︎ Mərdan Abdullayev earned a total of 30000 xp!
-♥︎ Koteczek and Джек reached a 275 day friend streak!
-♥︎ minh đăng completed a 200 day streak!
-♥︎ Гончаров кинни бсд Пётр |[フΨ] collected the april badge!
-♥︎ hajun16kim and 또잉 reached a 7 day friend streak!
-♥︎ Bin played 5 chess matches in a day!
-♥︎ 青色 and あやや reached a 7 day friend streak!
-♥︎ K.EMBAPPE and Samtherizzman123 reached a 3 day friend streak!
-♥︎ yamamamayamama did more than 10 lessons in a day!
-♥︎ Yic0714 and tammam reached a 150 day friend streak!
+   ☆彡starsha ♡(⁠=⁠^⁠･⁠ｪ⁠･⁠^⁠=⁠)☆ finished #1 in the diamond league 71 times!
+   Lesley completed a 1100 day streak!
+   #:Dani and Fladinei reached a 275 day friend streak!
+   ☆彡starsha ♡(⁠=⁠^⁠･⁠ｪ⁠･⁠^⁠=⁠)☆ reached a duolingo japanese score of 90!
+   İremnur reached a duolingo french score of 5!
+   Thomé reached a duolingo italian score of 83!
+   nayun1202 and Junhee reached a 14 day friend streak!
+   Jenny Lee played 5 chess matches in a day!
+   justusw833 completed a 7 day streak!
+   can reached a duolingo spanish score of 55!
+   Yic0714 reached a 1000 elo rating in chess!
+   Laura did more than 10 lessons in a day!
+   Kitsunet20170403 won 10 chess matches. check and mate!
+   vilbi761 completed a 14 day streak!
+   Richard Chadburn reached a duolingo french score of 68!
+💚 Francesco did more than 10 lessons in a day!
+💚 Victor Hugo did more than 10 lessons in a day!
+💚 Theodor and Sergey reached a 625 day friend streak!
+💚 drumwhacker reached a duolingo german score of 81!
+💚 aninha kopceski completed a total of 100 perfect lessons!
+💚 Çiğdem completed 5 friends quests in a row!
+💚 Diego and MissElizabethG reached a 3 day friend streak!
+💚 Francesco reached a duolingo english score of 69!
+💚 eu and gi reached a 400 day friend streak!
+💚 Yelitza and Antonio reached a 175 day friend streak!
+💚 djwvdjeb completed a 100 day streak!
+💚 Büsra Dölek won 100 chess matches. check and mate!
+💚 Vicky and Mai reached a 125 day friend streak!
+💚 ,rima and asya_7 A reached a 30 day friend streak!
+💚 Marzenna and Katie reached a 675 day friend streak!
+💚 Nhi and Susanne reached a 175 day friend streak!
+💚 Jackie Prado completed 10 friends quests in a row!
+💚 seher ★ finished top 3 and was promoted to the pearl league!
+💚 Viktoriia completed a 300 day streak!
+💚 Alexey and Александр reached a 150 day friend streak!
+💚 Smt S completed a 250 day streak!
+💚 jeannemiaou. completed 5 friends quests in a row!
+💚 Marina and Людмила reached a 14 day friend streak!
+💚 AŽ completed 70 friends quests in a row!
+💚 Alexander completed a 1600 day streak!
+💚 Татьяна did more than 10 lessons in a day!
+💚 Sony completed 20 friends quests in a row!
+💚 Mərdan and Franklin reached a 75 day friend streak!
+💚 Ana and Artur reached a 675 day friend streak!
+💚 Ingrid reached a duolingo spanish score of 110!
+💚 ANONYME shared a sentence 
+💚 carky crak collected the may badge!
+💚 Aki and Aideè reached a 675 day friend streak!
+💚 Unicornia264 completed a 100 day streak!
+💚 Angel shared a sentence 
+💚 Angel shared a sentence 
+💚 Angel shared a sentence 
+💚 ✨KENDYS-D✨ played 5 chess matches in a day!
+💚 Hans Svendsen did more than 10 lessons in a day!
+💚 jefry2020 completed a 365 day streak!
+💚 jefry2020 and Fonsy0 reached a 30 day friend streak!
+💚 Maryam completed a 2500 day streak!
+💚 ayse and gianluc reached a 600 day friend streak!
+💚 justusw833 won 10 chess matches. check and mate!
+💚 Amber completed 15 friends quests in a row!
+💚 justusw833 earned a total of 2000 xp!
+💚 Naman and John reached a 150 day friend streak!
+💚 محمد اسماعيل علي مهدي الموشكي reached a duolingo english score of 81!
+💚 Laura and Lackó reached a 14 day friend streak!
+💚 Quỳnh Anh won 75 chess matches. check and mate!
+💚 Rapha1424 reached a duolingo german score of 15!
+💚 Puji Maulani Lestari completed a 30 day streak!
+💚 Jun I reached a duolingo english score of 107!
+💚 Сергей shared a sentence 
+💚 Сергей completed a 500 day streak!
+💚 ゆ and Karolina reached a 175 day friend streak!
+💚 DENİZ earned a total of 20000 xp!
+💚 ThisIsACatTripping and Małgorzata reached a 14 day friend streak!
+💚 walat and Éva B L reached a 125 day friend streak!
+💚 イク did more than 10 lessons in a day!
+💚 Nguyễn Thanh Vy❤️ did more than 10 lessons in a day!
+💚 Nguyễn Thanh Vy❤️ played 5 chess matches in a day!
+💚 Nguyễn Thanh Vy❤️ won 100 chess matches. check and mate!
+💚 Maryjose reached a duolingo french score of 7!
+💚 Naysú finished top 3 and was promoted to the pearl league!
+💚 Ania finished top 3 and was promoted to the diamond league!
+💚 Gerda completed a 1100 day streak!
+💚 Francesco and Sílvia reached a 600 day friend streak!
+💚 kakao798117 shared a sentence 
+💚 Валаа Эльхадж won 400 chess matches. check and mate!
+💚 Ana reached a duolingo spanish score of 123!
+💚 hajun16kim and walker reached a 30 day friend streak!
+💚 Gül completed 5 friends quests in a row!
+💚 Ahad muhammed CR7 won 10 chess matches. check and mate!
+💚 Karin Hallgren completed 10 friends quests in a row!
+💚 ohyoondi12 and z4OEcO7L reached a 3 day friend streak!
+💚 Thomé and Belme reached a 675 day friend streak!
+💚 Ольга ✨ reached a duolingo english score of 128!
+💚 Richard Chadburn did more than 10 lessons in a day!
+   An unexpected method to boost your vocab just dropped! 📲
+   If you’re a chess fanatic planning your next trip, don’t miss these destinations!
+   Struggling to know *which* chess move is best during your games? Read our tips!
+   Big news 📰 We’ve expanded our most popular courses with more advanced content!
 "
 `;
 
 snapshot[`duolingo feed --engage 1`] = `
 "
-♥︎ Mary Borisova did more than 10 lessons in a day!
-♥︎ Ольга ✨ reached a duolingo english score of 127!
-♥︎ susan completed 70 friends quests in a row!
-♥︎ Zaineb collected the april badge!
-♥︎ Zaineb completed 3 friends quests in a row!
-♥︎ huyen did more than 10 lessons in a day!
-♥︎ Ariana Khodyreva played 5 chess matches in a day!
-♥︎ it's nazli 12 tacowa played 5 chess matches in a day!
-♥︎ it's nazli 12 tacowa did more than 10 lessons in a day!
-♥︎ Ariana Khodyreva won 10 chess matches. check and mate!
-♥︎ piccola reached a duolingo italian score of 63!
-♥︎ Anna and Sandra reached a 125 day friend streak!
-♥︎ angeles soto lopez completed 15 friends quests in a row!
-♥︎ Cindy finished #1 in the diamond league 100 times!
-♥︎ &ko collected the april badge!
-♥︎ Piet collected the april badge!
-♥︎ Татьяна completed 65 friends quests in a row!
-♥︎ Vanessa Ortega completed a 100 day streak!
-♥︎ Vanessa and Daicy reached a 50 day friend streak!
-♥︎ ♡M♡ shared a sentence
-♥︎ Kitsunet20170403 completed a 250 day streak!
-♥︎ Smt S completed 35 friends quests in a row!
-♥︎ Arlette and El reached a 575 day friend streak!
-♥︎ ✨ and Reyyan reached a 30 day friend streak!
-♥︎ ♡M♡ shared a sentence
-♥︎ ♡M♡ shared a sentence
-♥︎ Ricky Harper reached a duolingo english score of 130!
-♥︎ Roberto completed 5 friends quests in a row!
-♥︎ HalloI’m Japanese I like game finished top 3 and was promoted to the amethyst league!
-♥︎ mi completed 10 friends quests in a row!
-♥︎ carito and LizzyLegend#7 reached a 3 day friend streak!
-♥︎ Bob advanced to the finals of the diamond tournament!
-♥︎ liseth Castro completed a 7 day streak!
-♥︎ Mayara advanced to the semifinals of the diamond tournament!
-♥︎ Svitlana and Stephen reached a 675 day friend streak!
-♥︎ AŽ collected the april badge!
-♥︎ @Amin_mgh99 collected the april badge!
-♥︎ Quintin and Ibtissam reached a 30 day friend streak!
-♥︎ Regulita and gaborke reached a 50 day friend streak!
-♥︎ Smt and Bahar reached a 200 day friend streak!
-♥︎ CashBuckets reached a duolingo english score of 60!
-♥︎ Sarka completed 80 friends quests in a row!
-♥︎ Aylin and Leyla reached a 75 day friend streak!
-♥︎ Theodor Berkinblit collected the april badge!
-♥︎ Vicky collected the april badge!
-♥︎ Lololo124 reached a duolingo italian score of 8!
-♥︎ Bilge Özkan Özkavak collected the april badge!
-♥︎ محمد اسماعيل علي مهدي الموشكي reached a duolingo english score of 78!
-♥︎ [♤you and Nurettin reached a 3 day friend streak!
-♥︎ Vanessa shared a sentence
-♥︎ Татьяна did more than 10 lessons in a day!
-♥︎ Vanessa shared a sentence
-♥︎ Hamza reached a duolingo english score of 88!
-♥︎ Damla completed 3 friends quests in a row!
-♥︎ Миша and Светлана reached a 3 day friend streak!
-♥︎ Cris completed 5 friends quests in a row!
-♥︎ Sebastian and Ailing reached a 125 day friend streak!
-♥︎ kocymm completed a total of 50 perfect lessons!
-♥︎ منصف did more than 10 lessons in a day!
-♥︎ io finished top 3 and was promoted to the amethyst league!
-♥︎ Çınar Sezen reached a duolingo english score of 129!
-♥︎ Jacksmack704 collected the april badge!
-♥︎ rita and Deme reached a 325 day friend streak!
-♥︎ Koss collected the april badge!
-♥︎ Çınar Sezen won 50 chess matches. check and mate!
-♥︎ Cris and Антон reached a 3 day friend streak!
-♥︎ Cemre and Eda reached a 50 day friend streak!
-♥︎ abc completed 30 friends quests in a row!
-♥︎ abc and Yuu reached a 14 day friend streak!
-♥︎ Mapali and Werner reached a 200 day friend streak!
-♥︎ Elenise did more than 10 lessons in a day!
-♥︎ ANONYME 2015 won their first chess match. checkmate!
-♥︎ Erone2016 collected the april badge!
-♥︎ Sandra reached a duolingo spanish score of 91!
-♥︎ Robin and Donncha reached a 650 day friend streak!
-♥︎ atas and Natalia reached a 365 day friend streak!
-♥︎ Mobsbacke and Charlie reached a 14 day friend streak!
-♥︎ leroi555 collected the april badge!
-♥︎ Jun and Милана reached a 3 day friend streak!
-♥︎ Anna won 4350 chess matches. check and mate!
-♥︎ undefined struggling to know *which* chess move is best during your games? read our tips!
-♥︎ Emine and nguyễn reached a 550 day friend streak!
-♥︎ Nick and Fred reached a 475 day friend streak!
-♥︎ Delcy and Zulay reached a 675 day friend streak!
-♥︎ Trần HaNa won their first chess match. checkmate!
-♥︎ Ricky Harper completed 3 friends quests in a row!
-♥︎ Mobsbacke completed a 50 day streak!
-♥︎ Trần HaNa reached a duolingo english score of 25!
-♥︎ Trần HaNa collected the april badge!
-♥︎ Sandra completed 55 friends quests in a row!
-♥︎ Mərdan Abdullayev earned a total of 30000 xp!
-♥︎ Koteczek and Джек reached a 275 day friend streak!
-♥︎ minh đăng completed a 200 day streak!
-♥︎ Гончаров кинни бсд Пётр |[フΨ] collected the april badge!
-♥︎ hajun16kim and 또잉 reached a 7 day friend streak!
-♥︎ Bin played 5 chess matches in a day!
-♥︎ 青色 and あやや reached a 7 day friend streak!
-♥︎ K.EMBAPPE and Samtherizzman123 reached a 3 day friend streak!
-♥︎ yamamamayamama did more than 10 lessons in a day!
-♥︎ Yic0714 and tammam reached a 150 day friend streak!
+💚 ☆彡starsha ♡(⁠=⁠^⁠･⁠ｪ⁠･⁠^⁠=⁠)☆ finished #1 in the diamond league 71 times!
+💚 Lesley completed a 1100 day streak!
+💚 #:Dani and Fladinei reached a 275 day friend streak!
+💚 ☆彡starsha ♡(⁠=⁠^⁠･⁠ｪ⁠･⁠^⁠=⁠)☆ reached a duolingo japanese score of 90!
+💚 İremnur reached a duolingo french score of 5!
+💚 Thomé reached a duolingo italian score of 83!
+💚 nayun1202 and Junhee reached a 14 day friend streak!
+💚 Jenny Lee played 5 chess matches in a day!
+💚 justusw833 completed a 7 day streak!
+💚 can reached a duolingo spanish score of 55!
+💚 Yic0714 reached a 1000 elo rating in chess!
+💚 Laura did more than 10 lessons in a day!
+💚 Kitsunet20170403 won 10 chess matches. check and mate!
+💚 vilbi761 completed a 14 day streak!
+💚 Richard Chadburn reached a duolingo french score of 68!
+💚 Francesco did more than 10 lessons in a day!
+💚 Victor Hugo did more than 10 lessons in a day!
+💚 Theodor and Sergey reached a 625 day friend streak!
+💚 drumwhacker reached a duolingo german score of 81!
+💚 aninha kopceski completed a total of 100 perfect lessons!
+💚 Çiğdem completed 5 friends quests in a row!
+💚 Diego and MissElizabethG reached a 3 day friend streak!
+💚 Francesco reached a duolingo english score of 69!
+💚 eu and gi reached a 400 day friend streak!
+💚 Yelitza and Antonio reached a 175 day friend streak!
+💚 djwvdjeb completed a 100 day streak!
+💚 Büsra Dölek won 100 chess matches. check and mate!
+💚 Vicky and Mai reached a 125 day friend streak!
+💚 ,rima and asya_7 A reached a 30 day friend streak!
+💚 Marzenna and Katie reached a 675 day friend streak!
+💚 Nhi and Susanne reached a 175 day friend streak!
+💚 Jackie Prado completed 10 friends quests in a row!
+💚 seher ★ finished top 3 and was promoted to the pearl league!
+💚 Viktoriia completed a 300 day streak!
+💚 Alexey and Александр reached a 150 day friend streak!
+💚 Smt S completed a 250 day streak!
+💚 jeannemiaou. completed 5 friends quests in a row!
+💚 Marina and Людмила reached a 14 day friend streak!
+💚 AŽ completed 70 friends quests in a row!
+💚 Alexander completed a 1600 day streak!
+💚 Татьяна did more than 10 lessons in a day!
+💚 Sony completed 20 friends quests in a row!
+💚 Mərdan and Franklin reached a 75 day friend streak!
+💚 Ana and Artur reached a 675 day friend streak!
+💚 Ingrid reached a duolingo spanish score of 110!
+💚 ANONYME shared a sentence 
+💚 carky crak collected the may badge!
+💚 Aki and Aideè reached a 675 day friend streak!
+💚 Unicornia264 completed a 100 day streak!
+💚 Angel shared a sentence 
+💚 Angel shared a sentence 
+💚 Angel shared a sentence 
+💚 ✨KENDYS-D✨ played 5 chess matches in a day!
+💚 Hans Svendsen did more than 10 lessons in a day!
+💚 jefry2020 completed a 365 day streak!
+💚 jefry2020 and Fonsy0 reached a 30 day friend streak!
+💚 Maryam completed a 2500 day streak!
+💚 ayse and gianluc reached a 600 day friend streak!
+💚 justusw833 won 10 chess matches. check and mate!
+💚 Amber completed 15 friends quests in a row!
+💚 justusw833 earned a total of 2000 xp!
+💚 Naman and John reached a 150 day friend streak!
+💚 محمد اسماعيل علي مهدي الموشكي reached a duolingo english score of 81!
+💚 Laura and Lackó reached a 14 day friend streak!
+💚 Quỳnh Anh won 75 chess matches. check and mate!
+💚 Rapha1424 reached a duolingo german score of 15!
+💚 Puji Maulani Lestari completed a 30 day streak!
+💚 Jun I reached a duolingo english score of 107!
+💚 Сергей shared a sentence 
+💚 Сергей completed a 500 day streak!
+💚 ゆ and Karolina reached a 175 day friend streak!
+💚 DENİZ earned a total of 20000 xp!
+💚 ThisIsACatTripping and Małgorzata reached a 14 day friend streak!
+💚 walat and Éva B L reached a 125 day friend streak!
+💚 イク did more than 10 lessons in a day!
+💚 Nguyễn Thanh Vy❤️ did more than 10 lessons in a day!
+💚 Nguyễn Thanh Vy❤️ played 5 chess matches in a day!
+💚 Nguyễn Thanh Vy❤️ won 100 chess matches. check and mate!
+💚 Maryjose reached a duolingo french score of 7!
+💚 Naysú finished top 3 and was promoted to the pearl league!
+💚 Ania finished top 3 and was promoted to the diamond league!
+💚 Gerda completed a 1100 day streak!
+💚 Francesco and Sílvia reached a 600 day friend streak!
+💚 kakao798117 shared a sentence 
+💚 Валаа Эльхадж won 400 chess matches. check and mate!
+💚 Ana reached a duolingo spanish score of 123!
+💚 hajun16kim and walker reached a 30 day friend streak!
+💚 Gül completed 5 friends quests in a row!
+💚 Ahad muhammed CR7 won 10 chess matches. check and mate!
+💚 Karin Hallgren completed 10 friends quests in a row!
+💚 ohyoondi12 and z4OEcO7L reached a 3 day friend streak!
+💚 Thomé and Belme reached a 675 day friend streak!
+💚 Ольга ✨ reached a duolingo english score of 128!
+💚 Richard Chadburn did more than 10 lessons in a day!
+💚 An unexpected method to boost your vocab just dropped! 📲
+💚 If you’re a chess fanatic planning your next trip, don’t miss these destinations!
+💚 Struggling to know *which* chess move is best during your games? Read our tips!
+💚 Big news 📰 We’ve expanded our most popular courses with more advanced content!
 "
 `;
 
 snapshot[`duolingo follows 1`] = `
 "
-👤 Following 525 people.
-👤 Followed by 1026 people.
+👤 Following 532 people.
+👤 Followed by 1038 people.
 "
 `;
 
 snapshot[`duolingo follows --follow 1`] = `
 "
-👤 Following 525 people.
-👤 Followed by 1026 people.
-✅ Followed carky crak.
-✅ Followed herkal.
-✅ Followed jeannemiaou..
+👤 Following 532 people.
+👤 Followed by 1038 people.
+✅ Followed Burcu.
+✅ Followed Zane Ķirsone.
+✅ Followed ОБОЮДНО.
+✅ Followed Mihriban.
+✅ Followed hasan.
+✅ Followed leroi555.
+✅ Followed Requin55J.
+✅ Followed Bruno1.
+✅ Followed 顏名菲_Miffy.
+✅ Followed Duocorn33.
 "
 `;
 
 snapshot[`duolingo follows --unfollow 1`] = `
 "
-👤 Following 528 people.
-👤 Followed by 1026 people.
-❌ Unfollowed Stina.
-❌ Unfollowed Erivan.
-❌ Unfollowed Andrii.
-❌ Unfollowed i'm quitting because of hiatus.
-❌ Unfollowed Сергей Иванищев.
-❌ Unfollowed LadyBug_en Paris.
+👤 Following 542 people.
+👤 Followed by 1038 people.
+❌ Unfollowed Norbert.
+❌ Unfollowed Ben.
+❌ Unfollowed Karin Hallgren.
+❌ Unfollowed bananova_slupka.
+❌ Unfollowed Alexander.
+❌ Unfollowed Sansan.
+❌ Unfollowed Marie Sarger.
+❌ Unfollowed Elisa G.
+❌ Unfollowed Agnese Klindžāne-Klinšāne.
+❌ Unfollowed Roghy Mahmoudi.
+❌ Unfollowed Lenny.
+❌ Unfollowed Paty.
+❌ Unfollowed Jessi.
+❌ Unfollowed Martha.
+❌ Unfollowed Monika Orosz.
+❌ Unfollowed عبدالله ماريا.
+❌ Unfollowed David02BMW909.
+❌ Unfollowed Cookie.
+❌ Unfollowed Hatice Kurtgöz.
 ❌ Unfollowed Anaya.
-❌ Unfollowed Чипупеля.
-❌ Unfollowed Elif Öncel.
-❌ Unfollowed Юрий,(тех поддержка ) Яковенко.
-❌ Unfollowed slime804.
-❌ Unfollowed Ebrar Altınözek.
-❌ Unfollowed Quỳnh Anh.
-❌ Unfollowed dəfnə ibayeva.
+❌ Unfollowed ecgEva.
+❌ Unfollowed beron.
+❌ Unfollowed lelele_xyu.
 ❌ Unfollowed Oscar♟.
+❌ Unfollowed pedro Emanuel llamo Trujillo.
 "
 `;
 
 snapshot[`duolingo league 1`] = `
 "
-🏆  Finals                         
- 1. Tuğrul 👀               7653 XP
- 2. Greg Stone 🇪🇸           3427 XP
- 3. Stina 🎉                3165 XP
- 4. jeannette van alteren   2930 XP
- 5. Veaceslav Dinga         2809 XP
- 6. annita                  2285 XP
- 7. katyalingo 😺           2146 XP
- 8. Craig                   2101 XP
- 9. Jens Lütkemeier         2047 XP
-10. Denis 💪                2001 XP
-11. Lily 😎                 1952 XP
-12. Wilco van Es            1891 XP
-13. Magic Bensn 😎          1799 XP
-14. Svitlana                1577 XP
-15. LauraMeisje LMH 🇯🇵      1385 XP
+                                          
+ 1. Tuğrul 👀                     16371 XP
+ 2. Ben 💪                        13900 XP
+ 3. Agnese Klindžāne-Klinšāne     11398 XP
+ 4. Norbert 😡                     8711 XP
+ 5. hai 🏆                     👤  7157 XP
+ 6. Paty                           7010 XP
+ 7. Sansan                         6957 XP
+ 8. Marie Sarger                   6664 XP
+ 9. Miquel                         5046 XP
+10. bananova_slupka 💩             4476 XP
+11. Karin Hallgren 🇪🇸              4203 XP
+12. Roghy Mahmoudi 🏆              4031 XP
+13. Elisa G                        3705 XP
+14. Vyrna23                    👤  3512 XP
+15. Alexander 🇷🇺                   3111 XP
+16. Hans Svendsen 😎           👤  3064 XP
+17. YOONA 🏆                   👤  2322 XP
+18. Lenny 🏆                       1830 XP
+19. Dini Pol 😡                    1449 XP
+20. Klaidas Vaitkus                1378 XP
 "
 `;
 
 snapshot[`duolingo league --follow 1`] = `
 "
-✅ Followed Greg Stone.
-✅ Followed Stina.
-✅ Followed jeannette van alteren.
-✅ Followed Veaceslav Dinga.
-✅ Followed annita.
-✅ Followed katyalingo.
-✅ Followed Craig.
-✅ Followed Jens Lütkemeier.
-✅ Followed Denis.
-✅ Followed Lily.
-✅ Followed Wilco van Es.
-✅ Followed Magic Bensn.
-✅ Followed Svitlana.
-✅ Followed LauraMeisje LMH.
-🏆  Finals                         
- 1. Tuğrul 👀               7653 XP
- 2. Greg Stone 🇪🇸           3427 XP
- 3. Stina 🎉                3165 XP
- 4. jeannette van alteren   2930 XP
- 5. Veaceslav Dinga         2809 XP
- 6. annita                  2285 XP
- 7. katyalingo 😺           2146 XP
- 8. Craig                   2101 XP
- 9. Jens Lütkemeier         2047 XP
-10. Denis 💪                2001 XP
-11. Lily 😎                 1952 XP
-12. Wilco van Es            1891 XP
-13. Magic Bensn 😎          1799 XP
-14. Svitlana                1577 XP
-15. LauraMeisje LMH 🇯🇵      1385 XP
+✅ Followed Ben.
+✅ Followed Agnese Klindžāne-Klinšāne.
+✅ Followed Norbert.
+✅ Followed Paty.
+✅ Followed Sansan.
+✅ Followed Marie Sarger.
+✅ Followed Miquel.
+✅ Followed undefined.
+✅ Followed Karin Hallgren.
+✅ Followed Roghy Mahmoudi.
+✅ Followed Elisa G.
+✅ Followed Alexander.
+✅ Followed Lenny.
+✅ Followed Dini Pol.
+✅ Followed Klaidas Vaitkus.
+                                          
+ 1. Tuğrul 👀                     16371 XP
+ 2. Ben 💪                        13900 XP
+ 3. Agnese Klindžāne-Klinšāne     11398 XP
+ 4. Norbert 😡                     8711 XP
+ 5. hai 🏆                     👤  7157 XP
+ 6. Paty                           7010 XP
+ 7. Sansan                         6957 XP
+ 8. Marie Sarger                   6664 XP
+ 9. Miquel                         5046 XP
+10. bananova_slupka 💩             4476 XP
+11. Karin Hallgren 🇪🇸              4203 XP
+12. Roghy Mahmoudi 🏆              4031 XP
+13. Elisa G                        3705 XP
+14. Vyrna23                    👤  3512 XP
+15. Alexander 🇷🇺                   3111 XP
+16. Hans Svendsen 😎           👤  3064 XP
+17. YOONA 🏆                   👤  2322 XP
+18. Lenny 🏆                       1830 XP
+19. Dini Pol 😡                    1449 XP
+20. Klaidas Vaitkus                1378 XP
 "
 `;

--- a/duolingo/cli.ts
+++ b/duolingo/cli.ts
@@ -14,13 +14,12 @@ import { version } from "@roka/forge/version";
 import { plain } from "@roka/html/plain";
 import { maybe } from "@roka/maybe";
 import { distinctBy, pick } from "@std/collections";
-import { green, red } from "@std/fmt/colors";
+import { red } from "@std/fmt/colors";
 import type { Duolingo, FeedCard } from "./duolingo.ts";
 import { duolingo, LEAGUES } from "./duolingo.ts";
 import { leagueEmoji, leagueUserEmoji } from "./emoji.ts";
 
 const ERROR = red("✘");
-const KUDOS = green("♥︎");
 
 /** Options for the {@link cli} function. */
 export type CliOptions = {
@@ -93,9 +92,10 @@ export async function cli(options?: CliOptions): Promise<number> {
 
 function feedCommand(cfg: Config<CliOptions>) {
   function summary(card: FeedCard): string {
-    return `${card.header ? plain(card.header) : card.displayName} ${
-      plain(card.body).toLowerCase()
-    }`.trimEnd();
+    const name = card.header ? plain(card.header) : card.displayName;
+    const body = plain(card.body).trimEnd();
+    if (!name || body.startsWith(name)) return body;
+    return `${name} ${body.toLowerCase()}`;
   }
   return new Command()
     .description("Prints and interacts with the feed.")
@@ -135,7 +135,7 @@ function feedCommand(cfg: Config<CliOptions>) {
           if (engage) await react(card);
           if (!json) {
             console.log(
-              card.reactionType || engage ? KUDOS : " ",
+              card.reactionType || engage ? "💚" : "  ",
               summary(card),
             );
           }
@@ -260,7 +260,9 @@ function leagueCommand(config: Config<CliOptions>) {
               league.rankings.map((user, index) => [
                 `${index + 1}.`,
                 `${user.display_name} ${leagueUserEmoji(user)}`,
-                users.find((u) => u.id === user.user_id && u.isFollowing)
+                users.find((u) =>
+                    u.id === user.user_id && u.isFollowing && u.isFollowedBy
+                  )
                   ? "👤"
                   : "",
                 `${user.score.toString()} XP`,

--- a/duolingo/duolingo.ts
+++ b/duolingo/duolingo.ts
@@ -19,7 +19,7 @@
  * ```sh
  * export DUOLINGO_USERNAME=TugrulAtes
  * export DUOLINGO_TOKEN=token
- * deno run -A jsr:@tugrulates/duolingo/cli feed
+ * deno run -A --unstable-kv jsr:@tugrulates/duolingo/cli feed
  * ```
  *
  * @module duolingo


### PR DESCRIPTION
- do not repeat user names on feed follow events
- show mutual follows as friends on league command